### PR TITLE
Sticky Currency Selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tokes-payments-component",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokes-payments-component",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Tokes Platform payments Web Component",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/components/payment-portal/payment-portal.tsx
+++ b/src/components/payment-portal/payment-portal.tsx
@@ -121,7 +121,10 @@ export class PaymentPortal {
     try {
       const { success, order, payment } = await orderStatus(url, apiKey, referenceId);
       if (success) {
-        this.orderData = order;
+        if (this.navState !== NavState.Setup ||
+          (payment && payment.payment_status_id !== this.paymentData.payment_status_id)) {
+          this.orderData = order;
+        }
         this.paymentData = payment;
       }
 


### PR DESCRIPTION
## Description of Changes

- Prevent currency from auto-changing during selection
  - This was happening due to order refreshing automatically and updating the currency to whatever it is currently set at, prior to a user selecting a new currency to pay with

## Checklist

- [ ] UAT